### PR TITLE
Adding information about changing pipethrough's

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ pipeline :any do
 end
 ```
 
+Don't forget to change the pipeline you just changed inside the scopes.
+As such, you should change according to the following:
+
+*Before*:
+```elixir
+scope "/", AppWeb do
+  pipe_through(:browser)
+
+  get("/", PageController, :index)
+end
+```
+
+*After*:
+```elixir
+scope "/", AppWeb do
+  pipe_through(:any)
+
+  get("/", PageController, :index)
+end
+```
+
 Pass the plugs you want to run for `html`
 as `html_plugs` (_in the order you want to execute them_).
 


### PR DESCRIPTION
This should fix #15 .

I've added information so novices like me don't get confused when this error props up. This was due to not changing the pipeline definition inside the scoped routes. Now it's clear within the instructions when using this awesome plug 😄 .